### PR TITLE
Set encoding parameter for content type header

### DIFF
--- a/markdir.go
+++ b/markdir.go
@@ -65,7 +65,7 @@ func (r renderer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	output := blackfriday.MarkdownCommon(input)
 
-	rw.Header().Set("Content-Type", "text/html")
+	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	outputTemplate.Execute(rw, struct {
 		Path string

--- a/markdir.go
+++ b/markdir.go
@@ -42,7 +42,7 @@ type renderer struct {
 }
 
 func (r renderer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if !strings.HasSuffix(req.URL.Path, ".md") {
+	if !strings.HasSuffix(req.URL.Path, ".md") && !strings.HasSuffix(req.URL.Path, "/guide") {
 		r.h.ServeHTTP(rw, req)
 		return
 	}


### PR DESCRIPTION
Without this, unicode text like euro signs doesn't show up right. Also, render Acme style guide files (files with name `guide` are treated as sort of temporary scratchpads for note taking by Acme) as markdown.